### PR TITLE
Add cronjobs for MySQL & MongoDB s3 backups

### DIFF
--- a/k8s/openstad/environments/dev.values.yaml
+++ b/k8s/openstad/environments/dev.values.yaml
@@ -6,7 +6,7 @@ auth:
     image: draadnl/openstad-oauth2-server:develop-8c08c08-1663398735
 admin:
   deploymentContainer:
-    image: draadnl/openstad-management-panel:develop-cc1e766-1654216902
+    image: draadnl/openstad-management-panel:develop-ea2f657-1758001479
 api:
   deploymentContainer:
     image: draadnl/openstad-api:feature-allow-backup-cronjobs-to-be-run-by-a-k8s-cronjob-7e7133e-1755421037

--- a/k8s/openstad/templates/api/cronjob-mongodb.yaml
+++ b/k8s/openstad/templates/api/cronjob-mongodb.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       template:
         spec:
-          {{- include "openstad.imagePullSecret" . | nindent 10 }}
+          {{- include "openstad.imagePullSecret" . | indent 10 }}
           restartPolicy: OnFailure
           containers:
           - name: {{ template "openstad.api.fullname" . }}-mongodb-backup-job
@@ -25,8 +25,7 @@ spec:
             command: ["node", "backup.js"]
             args: []
             imagePullPolicy: IfNotPresent
-            resources:
-              {{ toYaml .Values.k8sCronjobs.mongodb.resources | nindent 14 }}
+            resources: {{ toYaml .Values.k8sCronjobs.mongodb.resources | nindent 14 }}
             env:
             - name: TZ
               value: {{ template "openstad.timezone" . }}

--- a/k8s/openstad/templates/api/cronjob-mongodb.yaml
+++ b/k8s/openstad/templates/api/cronjob-mongodb.yaml
@@ -9,10 +9,10 @@ metadata:
     {{- include "openstad.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ template "openstad.api.fullname" . }}-deployment
 spec:
-  schedule: "10 1 * * *"
+  schedule: {{- default "10 1 * * *" .Values.k8sCronjobs.mongodb.schedule }}
   concurrencyPolicy: "Forbid"
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: {{- default 3 .Values.k8sCronjobs.mongodb.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{- default 3 .Values.k8sCronjobs.mongodb.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:
@@ -26,12 +26,7 @@ spec:
             args: []
             imagePullPolicy: IfNotPresent
             resources:
-              limits:
-                cpu: "250m"
-                memory: "350M"
-              requests:
-                cpu: "250m"
-                memory: "250M"
+              {{ toYaml .Values.k8sCronjobs.mongodb.resources | indent 14 }}
             env:
             - name: TZ
               value: {{ template "openstad.timezone" . }}

--- a/k8s/openstad/templates/api/cronjob-mongodb.yaml
+++ b/k8s/openstad/templates/api/cronjob-mongodb.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   schedule: {{- default "10 1 * * *" .Values.k8sCronjobs.mongodb.schedule }}
   concurrencyPolicy: "Forbid"
-  successfulJobsHistoryLimit: {{- default 3 .Values.k8sCronjobs.mongodb.successfulJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{- default 3 .Values.k8sCronjobs.mongodb.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{- default "3" .Values.k8sCronjobs.mongodb.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{- default "3" .Values.k8sCronjobs.mongodb.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/k8s/openstad/templates/api/cronjob-mongodb.yaml
+++ b/k8s/openstad/templates/api/cronjob-mongodb.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.k8sCronjobs.mongodb.enabled -}}
+---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:

--- a/k8s/openstad/templates/api/cronjob-mongodb.yaml
+++ b/k8s/openstad/templates/api/cronjob-mongodb.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.k8sCronjobs.mongodb.enabled -}}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -72,3 +73,4 @@ spec:
                   fieldPath: metadata.namespace
             - name: BACKUP_TYPE
               value: mongo
+{{- end -}}

--- a/k8s/openstad/templates/api/cronjob-mongodb.yaml
+++ b/k8s/openstad/templates/api/cronjob-mongodb.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "openstad.api.fullname" . }}-cronjob-mongodb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openstad.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ template "openstad.api.fullname" . }}-deployment
+spec:
+  schedule: "10 1 * * *"
+  concurrencyPolicy: "Forbid"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          {{- include "openstad.imagePullSecret" . | nindent 10 }}
+          restartPolicy: OnFailure
+          containers:
+          - name: {{ template "openstad.api.fullname" . }}-mongodb-backup-job
+            image: {{ .Values.api.deploymentContainer.image }}
+            command: ["node", "backup.js"]
+            args: []
+            imagePullPolicy: IfNotPresent
+            env:
+            - name: TZ
+              value: {{ template "openstad.timezone" . }}
+            - name: S3_DBS_TO_BACKUP
+              value: "{{ .Values.S3.dbsToBackup }}"
+            - name: S3_MONGO_BACKUPS
+              value: "{{ .Values.S3.mongoBackups }}"
+            - name: S3_FORCE_PATH_STYLE
+              value: "{{ .Values.S3.forcePathStyle }}"
+            - name: S3_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  key: endpoint
+                  name: openstad-s3
+            - name: S3_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: key
+                  name: openstad-s3
+            - name: S3_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: secret
+                  name: openstad-s3
+            - name: S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  key: bucket
+                  name: openstad-s3
+            - name: MONGO_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: hostname
+                  name: openstad-mongo-credentials
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BACKUP_TYPE
+              value: mongo

--- a/k8s/openstad/templates/api/cronjob-mongodb.yaml
+++ b/k8s/openstad/templates/api/cronjob-mongodb.yaml
@@ -24,6 +24,13 @@ spec:
             command: ["node", "backup.js"]
             args: []
             imagePullPolicy: IfNotPresent
+            resources:
+              limits:
+                cpu: "250m"
+                memory: "350M"
+              requests:
+                cpu: "250m"
+                memory: "250M"
             env:
             - name: TZ
               value: {{ template "openstad.timezone" . }}

--- a/k8s/openstad/templates/api/cronjob-mongodb.yaml
+++ b/k8s/openstad/templates/api/cronjob-mongodb.yaml
@@ -9,10 +9,10 @@ metadata:
     {{- include "openstad.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ template "openstad.api.fullname" . }}-deployment
 spec:
-  schedule: {{- default "10 1 * * *" .Values.k8sCronjobs.mongodb.schedule }}
+  schedule: {{ .Values.k8sCronjobs.mongodb.schedule | default "10 1 * * *"  }}
   concurrencyPolicy: "Forbid"
-  successfulJobsHistoryLimit: {{- default "3" .Values.k8sCronjobs.mongodb.successfulJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{- default "3" .Values.k8sCronjobs.mongodb.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.k8sCronjobs.mongodb.successfulJobsHistoryLimit | default "3" }}
+  failedJobsHistoryLimit: {{ .Values.k8sCronjobs.mongodb.failedJobsHistoryLimit | default "3"}}
   jobTemplate:
     spec:
       template:
@@ -26,7 +26,7 @@ spec:
             args: []
             imagePullPolicy: IfNotPresent
             resources:
-              {{ toYaml .Values.k8sCronjobs.mongodb.resources | indent 14 }}
+              {{ toYaml .Values.k8sCronjobs.mongodb.resources | nindent 14 }}
             env:
             - name: TZ
               value: {{ template "openstad.timezone" . }}

--- a/k8s/openstad/templates/api/cronjob-mysql.yaml
+++ b/k8s/openstad/templates/api/cronjob-mysql.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       template:
         spec:
-          {{- include "openstad.imagePullSecret" . | nindent 10 }}
+          {{- include "openstad.imagePullSecret" . | indent 10 }}
           restartPolicy: OnFailure
           containers:
           - name: {{ template "openstad.api.fullname" . }}-mysql-backup-job
@@ -25,8 +25,7 @@ spec:
             command: ["node", "backup.js"]
             args: []
             imagePullPolicy: IfNotPresent
-            resources:
-              {{ toYaml .Values.k8sCronjobs.mysql.resources | nindent 14 }}
+            resources: {{ toYaml .Values.k8sCronjobs.mysql.resources | nindent 14 }}
             env:
             - name: TZ
               value: {{ template "openstad.timezone" . }}

--- a/k8s/openstad/templates/api/cronjob-mysql.yaml
+++ b/k8s/openstad/templates/api/cronjob-mysql.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.k8sCronjobs.mysql.enabled -}}
+---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:

--- a/k8s/openstad/templates/api/cronjob-mysql.yaml
+++ b/k8s/openstad/templates/api/cronjob-mysql.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "openstad.api.fullname" . }}-cronjob-mysql
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openstad.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ template "openstad.api.fullname" . }}-deployment
+spec:
+  schedule: "0 1 * * *"
+  concurrencyPolicy: "Forbid"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          {{- include "openstad.imagePullSecret" . | nindent 10 }}
+          restartPolicy: OnFailure
+          containers:
+          - name: {{ template "openstad.api.fullname" . }}-mysql-backup-job
+            image: {{ .Values.api.deploymentContainer.image }}
+            command: ["node", "backup.js"]
+            args: []
+            imagePullPolicy: IfNotPresent
+            env:
+            - name: TZ
+              value: {{ template "openstad.timezone" . }}
+            - name: S3_DBS_TO_BACKUP
+              value: "{{ .Values.S3.dbsToBackup }}"
+            - name: S3_FORCE_PATH_STYLE
+              value: "{{ .Values.S3.forcePathStyle }}"
+            - name: S3_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  key: endpoint
+                  name: openstad-s3
+            - name: S3_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: key
+                  name: openstad-s3
+            - name: S3_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: secret
+                  name: openstad-s3
+            - name: S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  key: bucket
+                  name: openstad-s3
+            - name: DEFAULT_DB
+              valueFrom:
+                secretKeyRef:
+                  key: database
+                  name: openstad-mongo-credentials
+            - name: API_DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: openstad-db-credentials
+            - name: API_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: mysql-password
+                  name: mysql-secret
+            - name: API_DATABASE_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  key: database
+                  name: openstad-api-db
+            - name: API_DATABASE_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: hostname
+                  name: openstad-db-credentials
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BACKUP_TYPE
+              value: mysql

--- a/k8s/openstad/templates/api/cronjob-mysql.yaml
+++ b/k8s/openstad/templates/api/cronjob-mysql.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   schedule: {{- default "0 1 * * *" .Values.k8sCronjobs.mysql.schedule }}
   concurrencyPolicy: "Forbid"
-  successfulJobsHistoryLimit: {{- default 3 .Values.k8sCronjobs.mongodb.successfulJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{- default 3 .Values.k8sCronjobs.mongodb.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{- default "3" .Values.k8sCronjobs.mongodb.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{- default "3" .Values.k8sCronjobs.mongodb.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/k8s/openstad/templates/api/cronjob-mysql.yaml
+++ b/k8s/openstad/templates/api/cronjob-mysql.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.k8sCronjobs.mysql.enabled -}}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -90,3 +91,4 @@ spec:
                   fieldPath: metadata.namespace
             - name: BACKUP_TYPE
               value: mysql
+{{- end -}}

--- a/k8s/openstad/templates/api/cronjob-mysql.yaml
+++ b/k8s/openstad/templates/api/cronjob-mysql.yaml
@@ -24,6 +24,13 @@ spec:
             command: ["node", "backup.js"]
             args: []
             imagePullPolicy: IfNotPresent
+            resources:
+              limits:
+                cpu: "250m"
+                memory: "350M"
+              requests:
+                cpu: "250m"
+                memory: "250M"
             env:
             - name: TZ
               value: {{ template "openstad.timezone" . }}

--- a/k8s/openstad/templates/api/cronjob-mysql.yaml
+++ b/k8s/openstad/templates/api/cronjob-mysql.yaml
@@ -9,10 +9,10 @@ metadata:
     {{- include "openstad.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ template "openstad.api.fullname" . }}-deployment
 spec:
-  schedule: "0 1 * * *"
+  schedule: {{- default "0 1 * * *" .Values.k8sCronjobs.mysql.schedule }}
   concurrencyPolicy: "Forbid"
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: {{- default 3 .Values.k8sCronjobs.mongodb.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{- default 3 .Values.k8sCronjobs.mongodb.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:
@@ -26,12 +26,7 @@ spec:
             args: []
             imagePullPolicy: IfNotPresent
             resources:
-              limits:
-                cpu: "250m"
-                memory: "350M"
-              requests:
-                cpu: "250m"
-                memory: "250M"
+              {{ toYaml .Values.k8sCronjobs.mysql.resources | indent 14 }}
             env:
             - name: TZ
               value: {{ template "openstad.timezone" . }}

--- a/k8s/openstad/templates/api/cronjob-mysql.yaml
+++ b/k8s/openstad/templates/api/cronjob-mysql.yaml
@@ -9,10 +9,10 @@ metadata:
     {{- include "openstad.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ template "openstad.api.fullname" . }}-deployment
 spec:
-  schedule: {{- default "0 1 * * *" .Values.k8sCronjobs.mysql.schedule }}
+  schedule: {{ .Values.k8sCronjobs.mysql.schedule | default "10 1 * * *"  }}
   concurrencyPolicy: "Forbid"
-  successfulJobsHistoryLimit: {{- default "3" .Values.k8sCronjobs.mongodb.successfulJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{- default "3" .Values.k8sCronjobs.mongodb.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.k8sCronjobs.mysql.successfulJobsHistoryLimit | default "3" }}
+  failedJobsHistoryLimit: {{ .Values.k8sCronjobs.mysql.failedJobsHistoryLimit | default "3"}}
   jobTemplate:
     spec:
       template:
@@ -26,7 +26,7 @@ spec:
             args: []
             imagePullPolicy: IfNotPresent
             resources:
-              {{ toYaml .Values.k8sCronjobs.mysql.resources | indent 14 }}
+              {{ toYaml .Values.k8sCronjobs.mysql.resources | nindent 14 }}
             env:
             - name: TZ
               value: {{ template "openstad.timezone" . }}

--- a/k8s/openstad/templates/api/deployment.yaml
+++ b/k8s/openstad/templates/api/deployment.yaml
@@ -55,6 +55,9 @@ spec:
           - name: PUBLIC_IP
             value: {{ .Values.host.publicIp }}
 
+          - name: PREVENT_BACKUP_CRONJOBS
+            value: "{{ .Values.api.preventBackupCronjobs }}"
+
           - name: S3_DBS_TO_BACKUP
             value: "{{ .Values.S3.dbsToBackup }}"
 

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -558,6 +558,27 @@ image:
       size:
         1Gi
 
+# Kubernetes cronjobs
+k8sCronjobs:
+  mongodb:
+    enabled: false
+    resources:
+      limits:
+        cpu: "250m"
+        memory: "350M"
+      requests:
+        cpu: "250m"
+        memory: "250M"
+  mysql:
+    enabled: false
+    resources:
+      limits:
+        cpu: "250m"
+        memory: "350M"
+      requests:
+        cpu: "250m"
+        memory: "250M"
+
 # Overwrite Secrets
 
 ##

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -562,6 +562,9 @@ image:
 k8sCronjobs:
   mongodb:
     enabled: false
+    schedule:
+    successfulJobsHistoryLimit:
+    failedJobsHistoryLimit:
     resources:
       limits:
         cpu: "250m"
@@ -571,6 +574,9 @@ k8sCronjobs:
         memory: "250M"
   mysql:
     enabled: false
+    schedule:
+    successfulJobsHistoryLimit:
+    failedJobsHistoryLimit:
     resources:
       limits:
         cpu: "250m"


### PR DESCRIPTION
This is done through the new backup.js file in the API.

Needs https://github.com/draadnl/openstad-api/pull/33 to be included in the API image.

Currently can be seen working on demo environment.